### PR TITLE
fix get_all_open_orders in binance_usds_m_futures_rest_api

### DIFF
--- a/cryptoxlib/clients/binance/BinanceFuturesClient.py
+++ b/cryptoxlib/clients/binance/BinanceFuturesClient.py
@@ -578,13 +578,14 @@ class BinanceUSDSMFuturesClient(BinanceFuturesClient):
 
         return await self._create_get("allOrders", params = params, headers = self._get_header(), signed = True, api_variable_path = BinanceUSDSMFuturesClient.FAPI_V1)
 
-    async def get_all_open_orders(self, pair: Pair, recv_window_ms: int = None) -> dict:
+    async def get_all_open_orders(self, pair: Pair = None, recv_window_ms: int = None) -> dict:
         params = CryptoXLibClient._clean_request_params({
-            "symbol": map_pair(pair),
             "recvWindow": recv_window_ms,
             "timestamp": self._get_current_timestamp_ms()
         })
 
+        if pair is not None:
+            params['symbol'] = map_pair(pair)
         return await self._create_get("openOrders", params = params, headers = self._get_header(), signed = True, api_variable_path = BinanceUSDSMFuturesClient.FAPI_V1)
 
     async def get_balance(self, recv_window_ms: int = None) -> dict:

--- a/examples/binance_usds_m_futures_rest_api.py
+++ b/examples/binance_usds_m_futures_rest_api.py
@@ -31,6 +31,46 @@ async def run():
     print("Order book:")
     await client.get_orderbook(symbol = Pair('BTC', 'USDT'), limit = enums.DepthLimit.L_5)
 
+    print("Trades:")
+    await client.get_trades(symbol=Pair('BTC', 'USDT'), limit = 5)
+
+    print("Historical trades:")
+    await client.get_historical_trades(symbol=Pair('BTC', 'USDT'), limit = 5)
+
+    print("Aggregate trades:")
+    await client.get_aggregate_trades(symbol=Pair('BTC', 'USDT'), limit = 5)
+
+    print("Index price candlesticks:")
+    await client.get_index_price_candlesticks(pair = Pair('BTC', 'USDT'), interval = enums.Interval.I_1MIN)
+
+    print("Index info:")
+    await client.get_index_info(pair = Pair('DEFI', 'USDT'))
+
+    print("24hour price ticker:")
+    await client.get_24h_price_ticker(pair = Pair('BTC', 'USDT'))
+
+    print("Price ticker:")
+    await client.get_price_ticker(pair = Pair('BTC', 'USDT'))
+
+    print("Best order book ticker:")
+    await client.get_orderbook_ticker(pair = Pair('BTC', 'USDT'))
+
+    print("Create limit order:")
+    try:
+        await client.create_order(Pair("BTC", "USDT"), side = enums.OrderSide.BUY, type = enums.OrderType.LIMIT,
+                                  quantity = "1",
+                                  price = "0",
+                                  time_in_force = enums.TimeInForce.GOOD_TILL_CANCELLED,
+                                  new_order_response_type = enums.OrderResponseType.FULL)
+    except BinanceException as e:
+        print(e)
+
+    print("Account:")
+    await client.get_account(recv_window_ms = 5000)
+
+    print("Account trades:")
+    await client.get_account_trades(pair = Pair('BTC', 'USDT'))
+
     print("All Open Orders:")
     await client.get_all_open_orders()
 

--- a/examples/binance_usds_m_futures_rest_api.py
+++ b/examples/binance_usds_m_futures_rest_api.py
@@ -31,45 +31,8 @@ async def run():
     print("Order book:")
     await client.get_orderbook(symbol = Pair('BTC', 'USDT'), limit = enums.DepthLimit.L_5)
 
-    print("Trades:")
-    await client.get_trades(symbol=Pair('BTC', 'USDT'), limit = 5)
-
-    print("Historical trades:")
-    await client.get_historical_trades(symbol=Pair('BTC', 'USDT'), limit = 5)
-
-    print("Aggregate trades:")
-    await client.get_aggregate_trades(symbol=Pair('BTC', 'USDT'), limit = 5)
-
-    print("Index price candlesticks:")
-    await client.get_index_price_candlesticks(pair = Pair('BTC', 'USDT'), interval = enums.Interval.I_1MIN)
-
-    print("Index info:")
-    await client.get_index_info(pair = Pair('DEFI', 'USDT'))
-
-    print("24hour price ticker:")
-    await client.get_24h_price_ticker(pair = Pair('BTC', 'USDT'))
-
-    print("Price ticker:")
-    await client.get_price_ticker(pair = Pair('BTC', 'USDT'))
-
-    print("Best order book ticker:")
-    await client.get_orderbook_ticker(pair = Pair('BTC', 'USDT'))
-
-    print("Create limit order:")
-    try:
-        await client.create_order(Pair("BTC", "USDT"), side = enums.OrderSide.BUY, type = enums.OrderType.LIMIT,
-                                  quantity = "1",
-                                  price = "0",
-                                  time_in_force = enums.TimeInForce.GOOD_TILL_CANCELLED,
-                                  new_order_response_type = enums.OrderResponseType.FULL)
-    except BinanceException as e:
-        print(e)
-
-    print("Account:")
-    await client.get_account(recv_window_ms = 5000)
-
-    print("Account trades:")
-    await client.get_account_trades(pair = Pair('BTC', 'USDT'))
+    print("All Open Orders:")
+    await client.get_all_open_orders()
 
     await client.close()
 


### PR DESCRIPTION
Reference:
https://binance-docs.github.io/apidocs/futures/cn/#user_data-5

the Pair is not necessary for this API